### PR TITLE
Remove unnecessary check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,8 +33,8 @@ module.exports = class Limiter {
       .pexpire([key, duration])
       .exec()
 
-    const count = parseInt(Array.isArray(res[0]) ? res[1][1] : res[1])
-    const oldest = parseInt(Array.isArray(res[0]) ? res[3][1] : res[3])
+    const count = parseInt(res[1][1])
+    const oldest = parseInt(res[3][1])
 
     return {
       remaining: count < max ? max - count : 0,


### PR DESCRIPTION
This package only works with ioredis. The code eliminated was originally added for support a different redis client
Related: https://github.com/tj/node-ratelimiter/pull/44/files\#diff-168726dbe96b3ce427e7fedce31bb0bcR77