### PR TITLE
Add "decrease" parameter to allow reading the values without changing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ Type: `number`
 
 How long keep records of requests in milliseconds. If provided, it overrides the default `duration` value.
 
+##### decrease
+
+Type: `boolean`
+
+When set to `false`, the remaining number of calls is not decreased. This is useful for just reading the remaining calls without actually decreasing them.
+
 
 ## License
 

--- a/test/index.js
+++ b/test/index.js
@@ -357,5 +357,24 @@ const RateLimiter = require('..')
         } while (times > 0)
       })
     })
+
+    describe('when get is called with decrease == false', function () {
+      it('should not decrement the remaining value', async function () {
+        let limit = new RateLimiter({
+          max: 5,
+          duration: 100000,
+          id: 'something',
+          db: db
+        })
+
+        let res
+        res = await limit.get({ decrease: false })
+        should(res.remaining).equal(5)
+        res = await limit.get({ decrease: false })
+        should(res.remaining).equal(5)
+        res = await limit.get({ decrease: false })
+        should(res.remaining).equal(5)
+      })
+    })
   })
 })


### PR DESCRIPTION
In some scenarios it might be useful to be able to read the current "remaining" value for a limiter. 

In this example, new login attempts are rejected when more at least 10 _unsuccessful_ login attempts happened in the last 60 seconds.

```
const rateLimiter = new RateLimiter({
  db: new Redis()
  max: 10
  duration: 60 * 1000
})

const loginHandler = async (req, res, next) => {
  const limit = await rateLimiter.get({ id: req.clientIp, decrease: false })
  if (!limit.remaining) return sendError(req, res, 429)

  try {
    await doLogin(req);// or something like this
  } catch (err) {
    if (err) {
      await rateLimiter.get({ id: req.clientIp })
      return sendError(req, res, 401)
    }
  }

  next(req, res)
}
```

This is done with a new `decrease` parameter that controls if the `remaining` value should actually be decreased (default: `true`) or if the request is only done to read the current value.

What do you think?