### PR TITLE
fix: update ioredis types usage for v5

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,33 +1,33 @@
 declare module 'async-ratelimiter' {
-  import Redis from 'ioredis';
+  import { Redis } from 'ioredis'
 
   namespace RateLimiter {
     interface ConstructorOptions {
-      db: Redis.Redis;
-      max?: number;
-      duration?: number;
-      namespace?: string;
-      id?: string;
+      db: Redis
+      max?: number
+      duration?: number
+      namespace?: string
+      id?: string
     }
 
     interface GetOptions {
-      id?: string;
-      max?: number;
-      duration?: number;
-      decrease?: boolean;
+      id?: string
+      max?: number
+      duration?: number
+      decrease?: boolean
     }
 
     interface Status {
-      total: number;
-      remaining: number;
-      reset: number;
+      total: number
+      remaining: number
+      reset: number
     }
   }
 
   class RateLimiter {
-    constructor(options: RateLimiter.ConstructorOptions);
-    get(options: RateLimiter.GetOptions): Promise<RateLimiter.Status>;
+    constructor(options: RateLimiter.ConstructorOptions)
+    get(options: RateLimiter.GetOptions): Promise<RateLimiter.Status>
   }
 
-  export = RateLimiter;
+  export = RateLimiter
 }


### PR DESCRIPTION
Fixes 

```
node_modules/async-ratelimiter/index.d.ts:6:11 - error TS2702: 'Redis' only refers to a type, but is being used as a namespace here.

6       db: Redis.Redis;
            ~~~~~
```